### PR TITLE
error with Array Index (contains the log id)

### DIFF
--- a/inc/global.inc.php
+++ b/inc/global.inc.php
@@ -681,17 +681,17 @@ function config_load( $load_user_configuration_dir = true )
 	{
 		case 'display':
 		case 'displayasc':
-			usort( $files , 'display_asc' );
+			uasort( $files , 'display_asc' );
 			break;
 		case 'displayi':
 		case 'displayiasc':
-			usort( $files , 'display_insensitive_asc' );
+			uasort( $files , 'display_insensitive_asc' );
 			break;
 		case 'displaydesc':
-			usort( $files , 'display_desc' );
+			uasort( $files , 'display_desc' );
 			break;
 		case 'displayidesc':
-			usort( $files , 'display_insensitive_desc' );
+			uasort( $files , 'display_insensitive_desc' );
 			break;
 		default:
 			# do not sort


### PR DESCRIPTION
The non administrator Users can't see the Log because the function "config_load" doesn't return the table with log Id.
usort doesn't keep the id of sorted array while uasort does.