### PR TITLE
Add leading and trailing slashes to the search regex field (if not empty) automatially

### DIFF
--- a/inc/getlog.pml.php
+++ b/inc/getlog.pml.php
@@ -106,6 +106,13 @@ $old_file_size       = (int) @$_POST['filesize'];
 $search              = @$_POST['search'];
 $old_lastline        = @$_POST['lastline'];
 
+// adds leading and trailing slashes to the search regex field (if not empty) automatially
+// without, you cant copy/paste a regex from the tester as it misses the required slashes.
+if (!empty($search)) {
+    $search = trim($search, '/');
+    $search = '/' . $search . '/';
+}
+
 header('Content-type: application/json');
 
 if ( ! csrf_verify() ) {


### PR DESCRIPTION
Without, you cant copy/paste a regex from the tester or from somewhere else as it misses the required slashes.
This drives you nuts if you don´t know.